### PR TITLE
create /etc/machine-id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,5 @@ RUN pacman -Syyu --noconfirm
 RUN pacman -S --noconfirm sudo
 
 RUN echo "%wheel        ALL=(ALL)       ALL" >> /etc/sudoers
+
+RUN touch /etc/machine-id


### PR DESCRIPTION
Creating a blank /etc/machine-id file fixes machine-id related errors like `Failed to replace specifiers: /run/log/journal/%m` when pacman is run etc. 

I haven't tested it with docker myself but I did test with the already built Arch-wsl. 