### PR TITLE
enable systemd support by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN pacman -Syyu --noconfirm
 
 RUN pacman -S --noconfirm sudo nano vim git base-devel wget curl
 
+RUN echo "[boot]" > /etc/wsl.conf
+RUN echo "systemd=true" >> /etc/wsl.conf
+
 RUN echo "%wheel        ALL=(ALL)       ALL" >> /etc/sudoers
 
 RUN touch /etc/machine-id


### PR DESCRIPTION
### Motivation
WSL now officially supports systemd as described [here](https://devblogs.microsoft.com/commandline/systemd-support-is-now-available-in-wsl/). Since many programs required systemd to work, this should make life easier.

### Changes
- add `/etc/wsl.conf`
```ini
[boot]
systemd=true
```


### NOTE
This changes how WSL behaves when booting up, which may introduce unknown side-effects. But everything (including WSLg) works perfectly fine on my machine. So, I think it's worth enabling it by default.