### PR TITLE
[fix] the keyring of Pacman is not initialized

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM vineelsai/arch:latest
 
 COPY . /
 
+RUN pacman-key --init
+
 RUN pacman -Syyu --noconfirm
 
 RUN pacman -S --noconfirm sudo nano vim git base-devel wget curl


### PR DESCRIPTION
## Motivation
When updating the package `archlinux-keyring`, I suddenly found that my arch's keyring was not initialized -- this should be obvious, but somehow I never noticed it before. 

While WSL should generally not be a target for cyber-attacks, it's always better to make the system that uses every day more secure.

## Breaking changes
None

[Ref](https://wiki.archlinux.org/title/Pacman/Package_signing#Initializing_the_keyring)